### PR TITLE
Update gitignore for build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,13 @@ modules.order
 Module.symvers
 Mkfile.old
 dkms.conf
+# vcore build outputs
+kernel
+kernel.bin
+boot/*.bin
+user/*/*.bin
+
+# Intermediate build files
+build/
+obj/
+


### PR DESCRIPTION
## Summary
- ignore generated kernel and boot binaries
- ignore binaries for user programs
- ignore build directories for object files

## Testing
- `make clean`
- `make` *(fails: `ld: cannot find lib.a`)*

------
https://chatgpt.com/codex/tasks/task_e_683ff95460b88324a95c8039c16382fd