### PR TITLE
Add stub network support with socket syscalls

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,20 @@
 CROSS ?=
 NASM = nasm
 CC = $(CROSS)gcc
-LD = $(CROSS)ld
+	LD = $(CROSS)ld
 OBJCOPY = $(CROSS)objcopy
 AR = $(CROSS)ar
-OBJDIR ?= build
-CFLAGS = -std=c99 -mcmodel=large -ffreestanding -fno-stack-protector -mno-red-zone -c
+	OBJDIR ?= build
+CFLAGS = -std=c99 -mcmodel=large -ffreestanding -fno-stack-protector -mno-red-zone -c -Isrc
 LDFLAGS = -nostdlib
-
+	
 C_SRCS := $(wildcard src/kernel/*.c)
+DRIVER_SRCS := $(wildcard src/drivers/net/*.c)
+NET_SRCS := $(wildcard src/net/*.c)
 ASM_SRCS := $(wildcard src/arch/x86/*.asm)
-C_OBJS := $(patsubst src/kernel/%.c,$(OBJDIR)/%.o,$(C_SRCS))
+C_OBJS := $(patsubst src/kernel/%.c,$(OBJDIR)/%.o,$(C_SRCS)) \
+$(patsubst src/drivers/net/%.c,$(OBJDIR)/%.o,$(DRIVER_SRCS)) \
+$(patsubst src/net/%.c,$(OBJDIR)/%.o,$(NET_SRCS))
 ASM_OBJS := $(patsubst src/arch/x86/%.asm,$(OBJDIR)/%_asm.o,$(ASM_SRCS))
 KERNEL_OBJS := $(ASM_OBJS) $(C_OBJS)
 
@@ -36,6 +40,12 @@ kernel: $(OBJDIR) $(KERNEL_OBJS)
 	$(OBJCOPY) -O binary kernel kernel.bin
 
 $(OBJDIR)/%.o: src/kernel/%.c | $(OBJDIR)
+	$(CC) $(CFLAGS) -o $@ $<
+
+$(OBJDIR)/%.o: src/drivers/net/%.c | $(OBJDIR)
+	$(CC) $(CFLAGS) -o $@ $<
+
+$(OBJDIR)/%.o: src/net/%.c | $(OBJDIR)
 	$(CC) $(CFLAGS) -o $@ $<
 
 $(OBJDIR)/%_asm.o: src/arch/x86/%.asm | $(OBJDIR)

--- a/libc/include/lib.h
+++ b/libc/include/lib.h
@@ -38,5 +38,8 @@ int delete_file(char *name);
 int fork(void);
 void exec(char *name);
 void *sbrk(int64_t inc);
+int socket(int type);
+int sendto(int sock, void *buf, uint32_t size);
+int recvfrom(int sock, void *buf, uint32_t size);
 
 #endif

--- a/libc/src/syscall.asm
+++ b/libc/src/syscall.asm
@@ -227,5 +227,44 @@ delete_file:
     add rsp,8
     ret
 
+; Socket system calls
+global socket
+global sendto
+global recvfrom
+
+socket:
+    sub rsp,8
+    mov eax,17
+    mov [rsp],rdi
+    mov rdi,1
+    mov rsi,rsp
+    int 0x80
+    add rsp,8
+    ret
+
+sendto:
+    sub rsp,24
+    mov eax,18
+    mov [rsp],rdi
+    mov [rsp+8],rsi
+    mov [rsp+16],rdx
+    mov rdi,3
+    mov rsi,rsp
+    int 0x80
+    add rsp,24
+    ret
+
+recvfrom:
+    sub rsp,24
+    mov eax,19
+    mov [rsp],rdi
+    mov [rsp+8],rsi
+    mov [rsp+16],rdx
+    mov rdi,3
+    mov rsi,rsp
+    int 0x80
+    add rsp,24
+    ret
+
 
 

--- a/src/drivers/net/e1000.c
+++ b/src/drivers/net/e1000.c
@@ -1,0 +1,31 @@
+#include "e1000.h"
+#include "kernel/print.h"
+
+/*
+ * This is a very small stub of the Intel E1000 driver. It only
+ * provides minimal hooks used by the network stack. A real driver
+ * would need to perform PCI discovery, MMIO setup and interrupt
+ * handling. Here we simply provide empty implementations so the rest
+ * of the kernel can be compiled and linked.
+ */
+
+void e1000_init(void)
+{
+    printk("e1000: init stub\n");
+}
+
+int e1000_send(const uint8_t *data, uint16_t len)
+{
+    (void)data;
+    (void)len;
+    printk("e1000: send stub\n");
+    return len;
+}
+
+int e1000_receive(uint8_t *buf, uint16_t buf_len)
+{
+    (void)buf;
+    (void)buf_len;
+    /* no data available */
+    return 0;
+}

--- a/src/drivers/net/e1000.h
+++ b/src/drivers/net/e1000.h
@@ -1,0 +1,7 @@
+#ifndef _E1000_H_
+#define _E1000_H_
+#include <stdint.h>
+void e1000_init(void);
+int e1000_send(const uint8_t *data, uint16_t len);
+int e1000_receive(uint8_t *buf, uint16_t buf_len);
+#endif

--- a/src/kernel/main.c
+++ b/src/kernel/main.c
@@ -4,6 +4,7 @@
 #include "process.h"
 #include "syscall.h"
 #include "file.h"
+#include "drivers/net/e1000.h"
 
 extern char bss_start;
 extern char bss_end;
@@ -17,6 +18,7 @@ void KMain(void)
    init_memory();
    init_kheap();
    init_kvm();
+   e1000_init();
    init_system_call();
    init_fs();
    init_process();

--- a/src/kernel/syscall.c
+++ b/src/kernel/syscall.c
@@ -6,6 +6,7 @@
 #include "debug.h"
 #include "stddef.h"
 #include "file.h"
+#include "net/socket.h"
 
 static SYSTEMCALL system_calls[20];
 
@@ -125,6 +126,21 @@ static int sys_delete_file(int64_t *argptr)
     return delete_file((char*)argptr[0]);
 }
 
+static int sys_socket(int64_t *argptr)
+{
+    return socket_create((int)argptr[0]);
+}
+
+static int sys_sendto(int64_t *argptr)
+{
+    return socket_send((int)argptr[0], (const void*)argptr[1], (int)argptr[2]);
+}
+
+static int sys_recvfrom(int64_t *argptr)
+{
+    return socket_recv((int)argptr[0], (void*)argptr[1], (int)argptr[2]);
+}
+
 void init_system_call(void)
 {
     system_calls[0] = sys_write;
@@ -144,6 +160,9 @@ void init_system_call(void)
     system_calls[14] = sys_create_file;
     system_calls[15] = sys_write_file;
     system_calls[16] = sys_delete_file;
+    system_calls[17] = sys_socket;
+    system_calls[18] = sys_sendto;
+    system_calls[19] = sys_recvfrom;
 }
 
 void system_call(struct TrapFrame *tf)
@@ -152,7 +171,7 @@ void system_call(struct TrapFrame *tf)
     int64_t param_count = tf->rdi;
     int64_t *argptr = (int64_t*)tf->rsi;
 
-    if (param_count < 0 || i > 16 || i < 0) {
+    if (param_count < 0 || i > 19 || i < 0) {
         tf->rax = -1;
         return;
     }

--- a/src/net/net.h
+++ b/src/net/net.h
@@ -1,0 +1,26 @@
+#ifndef _NET_H_
+#define _NET_H_
+#include <stdint.h>
+
+struct ip_header {
+    uint8_t ihl:4;
+    uint8_t version:4;
+    uint8_t tos;
+    uint16_t total_length;
+    uint16_t id;
+    uint16_t flags_fragment;
+    uint8_t ttl;
+    uint8_t protocol;
+    uint16_t checksum;
+    uint32_t src_ip;
+    uint32_t dst_ip;
+} __attribute__((packed));
+
+struct udp_header {
+    uint16_t src_port;
+    uint16_t dst_port;
+    uint16_t len;
+    uint16_t checksum;
+} __attribute__((packed));
+
+#endif

--- a/src/net/socket.c
+++ b/src/net/socket.c
@@ -1,0 +1,38 @@
+#include "socket.h"
+#include "drivers/net/e1000.h"
+#include "kernel/print.h"
+
+#define MAX_SOCKETS 16
+
+struct sock {
+    int used;
+    int type;
+};
+
+static struct sock sockets[MAX_SOCKETS];
+
+int socket_create(int type)
+{
+    for (int i = 0; i < MAX_SOCKETS; i++) {
+        if (!sockets[i].used) {
+            sockets[i].used = 1;
+            sockets[i].type = type;
+            return i;
+        }
+    }
+    return -1;
+}
+
+int socket_send(int sock, const void *buf, int len)
+{
+    if (sock < 0 || sock >= MAX_SOCKETS || !sockets[sock].used)
+        return -1;
+    return e1000_send(buf, (uint16_t)len);
+}
+
+int socket_recv(int sock, void *buf, int len)
+{
+    if (sock < 0 || sock >= MAX_SOCKETS || !sockets[sock].used)
+        return -1;
+    return e1000_receive(buf, (uint16_t)len);
+}

--- a/src/net/socket.h
+++ b/src/net/socket.h
@@ -1,0 +1,9 @@
+#ifndef _SOCKET_H_
+#define _SOCKET_H_
+#include <stdint.h>
+
+int socket_create(int type);
+int socket_send(int sock, const void *buf, int len);
+int socket_recv(int sock, void *buf, int len);
+
+#endif


### PR DESCRIPTION
## Summary
- stub Intel E1000 driver under `src/drivers/net`
- minimal socket layer and networking headers
- extend syscall infrastructure with `socket`, `sendto`, and `recvfrom`
- expose new syscalls to libc
- update build system to compile new sources

## Testing
- `make kernel`
- `make libc`
- `make users`
- `make all`


------
https://chatgpt.com/codex/tasks/task_e_6840756dacd08324a49412cd71de96dc