### PR TITLE
Add dependencies to toolchain script

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,9 @@ The Makefile uses tools like `$(CROSS)gcc`, `$(CROSS)ld`, and
 A helper script `scripts/build-toolchain.sh` can build a suitable
 cross‑compiler.  It downloads and compiles binutils and GCC into
 `$HOME/opt/cross` (or the directory specified by the `PREFIX` variable).
-After running the script, point `CROSS` at the resulting prefix.
+The script also installs all required build dependencies on Debian
+systems using `apt`.  After running the script, point `CROSS` at the
+resulting prefix.
 
 ```bash
 ./scripts/build-toolchain.sh

--- a/scripts/build-toolchain.sh
+++ b/scripts/build-toolchain.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 set -e
 
+# Install build dependencies (Debian/Ubuntu)
+sudo apt-get update
+sudo apt-get install -y build-essential bison flex libgmp-dev libmpc-dev \
+    libmpfr-dev texinfo wget
+
 # Versions
 BINUTILS_VER=${BINUTILS_VER:-2.41}
 GCC_VER=${GCC_VER:-13.2.0}


### PR DESCRIPTION
## Summary
- ensure Debian packages are installed when building the toolchain
- mention the automatic dependency install in README

## Testing
- `make -n` *(fails: only prints initial command)*

------
https://chatgpt.com/codex/tasks/task_e_683fee67d23483248f93f52f66f8b5b6