### PR TITLE
Update QEMU RAM requirement

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,5 +136,5 @@ clean:
 	rm -f user/*/*.o user/*/*.elf
 
 run: os.img
-	qemu-system-x86_64 -drive format=raw,file=os.img
+	qemu-system-x86_64 -m 1024 -drive format=raw,file=os.img
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ You can boot the resulting image with QEMU using the `run` target:
 make run
 ```
 
-This executes `qemu-system-x86_64 -drive format=raw,file=os.img`.
+This executes `qemu-system-x86_64 -m 1024 -drive format=raw,file=os.img`.
+Make sure to allocate at least 1&nbsp;GB of RAM when booting the image.
 
 ## Networking
 


### PR DESCRIPTION
## Summary
- allocate RAM when running the image
- document minimum RAM requirement in README

## Testing
- `make -n run` *(fails: `No rule to make target 'kernel.elf', needed by 'fs.img'. Stop.`)*

------
https://chatgpt.com/codex/tasks/task_e_6841044b8f6c8324b0f726c2c321836a