### PR TITLE
Dynamic loader size

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,8 @@ $(patsubst src/net/%.c,$(OBJDIR)/%.o,$(NET_SRCS))
 ASM_OBJS := $(patsubst src/arch/x86/%.asm,$(OBJDIR)/%_asm.o,$(ASM_SRCS))
 KERNEL_OBJS := $(ASM_OBJS) $(C_OBJS)
 FS_IMG := fs.img
+LOADER_BIN := boot/loader/loader.bin
+LOADER_SECTORS = $(shell python3 -c "import os,math; size=os.path.getsize('$(LOADER_BIN)') if os.path.exists('$(LOADER_BIN)') else 0; print((size+511)//512)")
 
 LIBC_C_SRCS := libc/src/printf.c libc/src/stdlib.c libc/src/string.c \
                libc/src/stdio.c libc/src/ctype.c libc/src/strtol.c \
@@ -64,8 +66,8 @@ $(LIBC_ARCHIVE): $(LIBC_OBJS)
 # Bootloader build
 bootloader: os.img
 
-boot/boot.bin: boot/boot.asm
-	$(NASM) -f bin -o $@ $<
+boot/boot.bin: boot/boot.asm $(LOADER_BIN)
+	$(NASM) -f bin -DLOADER_SECTORS=$(LOADER_SECTORS) -o $@ $<
 	
 boot/loader/entry.bin:
 	cd boot/loader && \
@@ -86,7 +88,7 @@ boot/loader/loader.bin: boot/loader/loader.asm boot/loader/entry.bin
 os.img: boot/boot.bin boot/loader/loader.bin $(FS_IMG)
 	rm -f $@
 	dd if=boot/boot.bin of=$@ bs=512 count=1 conv=notrunc
-	dd if=boot/loader/loader.bin of=$@ bs=512 count=15 seek=1 conv=notrunc
+	dd if=boot/loader/loader.bin of=$@ bs=512 count=$(LOADER_SECTORS) seek=1 conv=notrunc
 	dd if=$(FS_IMG) of=$@ bs=512 seek=63 conv=notrunc
 
 # User programs

--- a/boot/boot.asm
+++ b/boot/boot.asm
@@ -1,5 +1,8 @@
 [BITS 16]
 [ORG 0x7c00]
+%ifndef LOADER_SECTORS
+%define LOADER_SECTORS 15
+%endif
 
 start:
     xor ax,ax   
@@ -20,7 +23,7 @@ TestDiskExtension:
 LoadLoader:
     mov si,ReadPacket
     mov word[si],0x10
-    mov word[si+2],15
+    mov word[si+2],LOADER_SECTORS
     mov word[si+4],0x7e00
     mov word[si+6],0
     mov dword[si+8],1


### PR DESCRIPTION
## Summary
- compute loader size in sectors after building loader.bin
- define `LOADER_SECTORS` in Makefile
- pass `LOADER_SECTORS` to boot.asm and image generation
- update boot.asm to read loader based on computed size

## Testing
- `make all`

------
https://chatgpt.com/codex/tasks/task_e_684109e244288324b660f231ccf42eb4