### PR TITLE
Add loader debug prints

### DIFF
--- a/boot/loader/main.c
+++ b/boot/loader/main.c
@@ -53,7 +53,12 @@ static uint64_t load_kernel(char *name)
 
 void EMain(void)
 {
-   init_fs();
-   kernel_entry = load_kernel("KERNEL.ELF");
-   ASSERT(load_file("USER.ELF", 0x30000) == 0);
+    printk("loader: init_fs\n");
+    init_fs();
+
+    printk("loader: load_kernel\n");
+    kernel_entry = load_kernel("KERNEL.ELF");
+
+    printk("loader: load_file\n");
+    ASSERT(load_file("USER.ELF", 0x30000) == 0);
 }


### PR DESCRIPTION
## Summary
- print loader progress from `EMain`

## Testing
- `make all`
- `timeout 5 qemu-system-x86_64 -display none -serial mon:stdio -m 512 -drive format=raw,file=os.img -no-reboot -no-shutdown`

------
https://chatgpt.com/codex/tasks/task_e_68410e376418832491ab08c2a101f250