### PR TITLE
Ensure fs.img presence during build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,6 +86,7 @@ boot/loader/loader.bin: boot/loader/loader.asm boot/loader/entry.bin
 		dd if=entry.bin >> loader.bin
 	
 os.img: boot/boot.bin boot/loader/loader.bin $(FS_IMG)
+	test -f $(FS_IMG)
 	rm -f $@
 	dd if=boot/boot.bin of=$@ bs=512 count=1 conv=notrunc
 	dd if=boot/loader/loader.bin of=$@ bs=512 count=$(LOADER_SECTORS) seek=1 conv=notrunc

--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ CROSS=$HOME/opt/cross/bin/x86_64-elf- make
 ## Building
 
 Run `make` at the repository root.  This compiles the kernel, bootloader
-and user programs and produces `os.img`.
+and user programs and produces `os.img`.  The resulting image
+should be roughly 100&nbsp;MB because it embeds a small FAT filesystem.
 
 ```bash
 make


### PR DESCRIPTION
## Summary
- verify fs.img exists before creating os.img
- mention OS image size in README

## Testing
- `make clean`
- `make all`

------
https://chatgpt.com/codex/tasks/task_e_684110768f8883249419836166b1becc