### PR TITLE
Dynamic bootloader entry sector calculation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,6 @@ ASM_OBJS := $(patsubst src/arch/x86/%.asm,$(OBJDIR)/%_asm.o,$(ASM_SRCS))
 KERNEL_OBJS := $(ASM_OBJS) $(C_OBJS)
 FS_IMG := fs.img
 LOADER_BIN := boot/loader/loader.bin
-ENTRY_SECTORS := $(shell python3 -c 'import os,math; print(math.ceil(os.path.getsize("boot/loader/entry.bin")/512))')
 
 LIBC_C_SRCS := libc/src/printf.c libc/src/stdlib.c libc/src/string.c \
                libc/src/stdio.c libc/src/ctype.c libc/src/strtol.c \
@@ -84,7 +83,10 @@ boot/loader/entry.bin:
 
 boot/loader/loader.bin: boot/loader/loader.asm boot/loader/entry.bin
 	cd boot/loader && \
-$(NASM) -f bin -DENTRY_SECTORS=$(ENTRY_SECTORS) -o loader.bin loader.asm && \
+	ENTRY_SECTORS=`python3 -c 'import os,math; \
+	print(math.ceil(os.path.getsize("entry.bin")/512))'` && \
+	$(NASM) -f bin -DENTRY_SECTORS=$$ENTRY_SECTORS \
+	-o loader.bin loader.asm && \
 	dd if=entry.bin >> loader.bin
 	
 os.img: boot/boot.bin boot/loader/loader.bin $(FS_IMG)


### PR DESCRIPTION
## Summary
- remove stale `ENTRY_SECTORS` variable
- compute entry sector count inside the loader recipe

## Testing
- `make boot/loader/loader.bin`

------
https://chatgpt.com/codex/tasks/task_e_684117446c3c83249fca4c277b7bb9d2