### PR TITLE
Add GRUB ISO build option

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,20 @@ This executes `qemu-system-x86_64 -m 1024 -drive format=raw,file=os.img`.
 
 **Note:** allocate at least 1&nbsp;GB of RAM when running the image.
 
+Alternatively an ISO image can be built using GRUB.  Run
+
+```bash
+make iso
+```
+
+which produces `os.iso`.  Boot it with
+
+```bash
+qemu-system-x86_64 -cdrom os.iso
+```
+
+The original bootloader based image `os.img` continues to work.
+
 ## Networking
 
 The kernel contains a very small driver for the Intel E1000 network

--- a/grub/grub.cfg
+++ b/grub/grub.cfg
@@ -1,0 +1,7 @@
+set default=0
+set timeout=0
+
+menuentry "vcore" {
+    multiboot2 /kernel.elf
+    boot
+}


### PR DESCRIPTION
## Summary
- provide simple GRUB configuration
- support building an ISO image with `grub-mkrescue`
- document running the ISO with QEMU

## Testing
- `make iso` *(fails: grub-mkrescue not found)*

------
https://chatgpt.com/codex/tasks/task_e_68411a7de41083249f16d0984e71b8e4