### PR TITLE
Enable ISO build on make all

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,9 +34,14 @@ LIBC_ARCHIVE := libc/libc.a
 $(OBJDIR):
 	mkdir -p $@
 
-.PHONY: all libc kernel bootloader users clean run iso
+.PHONY: all libc kernel bootloader users clean run run-iso iso
 
-all: libc kernel bootloader users
+HAVE_GRUB_MKRESCUE := $(shell command -v grub-mkrescue >/dev/null 2>&1 && echo yes)
+ifeq ($(HAVE_GRUB_MKRESCUE),yes)
+ALL_EXTRA := $(ISO_IMG)
+endif
+
+all: libc kernel bootloader users $(ALL_EXTRA)
 
 libc: $(LIBC_ARCHIVE)
 
@@ -150,6 +155,9 @@ clean:
 
 run: os.img
 	qemu-system-x86_64 -m 1024 -drive format=raw,file=os.img
+
+run-iso: $(ISO_IMG)
+	qemu-system-x86_64 -cdrom $(ISO_IMG)
 
 iso: $(ISO_IMG)
 

--- a/README.md
+++ b/README.md
@@ -33,8 +33,10 @@ CROSS=$HOME/opt/cross/bin/x86_64-elf- make
 ## Building
 
 Run `make` at the repository root.  This compiles the kernel, bootloader
-and user programs and produces `os.img`.  The resulting image
-should be roughly 100&nbsp;MB because it embeds a small FAT filesystem.
+and user programs and produces `os.img`.  If `grub-mkrescue` is
+available an additional ISO image `os.iso` is created.  The ISO build
+relies on the `grub-mkrescue` tool.  The resulting image should be
+roughly 100&nbsp;MB because it embeds a small FAT filesystem.
 
 ```bash
 make
@@ -57,8 +59,15 @@ Alternatively an ISO image can be built using GRUB.  Run
 ```bash
 make iso
 ```
+(requires the `grub-mkrescue` tool)
 
-which produces `os.iso`.  Boot it with
+which produces `os.iso`.  Boot it with the `run-iso` target:
+
+```bash
+make run-iso
+```
+
+or run
 
 ```bash
 qemu-system-x86_64 -cdrom os.iso


### PR DESCRIPTION
## Summary
- include ISO image in the default `all` target when `grub-mkrescue` is installed
- add a `run-iso` target for running the ISO with QEMU
- document the new behaviour and requirement for `grub-mkrescue`

## Testing
- `make -n all`
- `make -n run-iso`

------
https://chatgpt.com/codex/tasks/task_e_68411da802908324b5a33fce5adfd413