### PR TITLE
Check grub-mkrescue before iso build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -168,7 +168,9 @@ $(ISO_DIR)/boot/grub/grub.cfg: grub/grub.cfg
 
 
 $(ISO_IMG): $(ISO_DIR)/boot/grub/grub.cfg kernel users
+	command -v grub-mkrescue >/dev/null || \
+	    { echo 'Error: grub-mkrescue not found.' >&2; exit 1; }
 	cp kernel.elf $(ISO_DIR)
 	cp user/*/*.elf $(ISO_DIR)
-	grub-mkrescue -o $(ISO_IMG) $(ISO_DIR) >/dev/null
+	grub-mkrescue -o $@ $(ISO_DIR) >/dev/null
 	

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ CROSS=$HOME/opt/cross/bin/x86_64-elf- make
 Run `make` at the repository root.  This compiles the kernel, bootloader
 and user programs and produces `os.img`.  If `grub-mkrescue` is
 available an additional ISO image `os.iso` is created.  The ISO build
-relies on the `grub-mkrescue` tool.  The resulting image should be
+relies on the `grub-mkrescue` tool (install the `grub-pc-bin` package on Debian-based systems).  The resulting image should be
 roughly 100&nbsp;MB because it embeds a small FAT filesystem.
 
 ```bash


### PR DESCRIPTION
## Summary
- fail fast in the `os.iso` recipe if `grub-mkrescue` is not present
- document how to obtain `grub-mkrescue` on Debian-based systems

## Testing
- `make clean`
- `make`
- `make iso` *(fails: `Error: grub-mkrescue not found.`)*

------
https://chatgpt.com/codex/tasks/task_e_68411e8f7e1483249b47f55e3666a1f2