### PR TITLE
Add iso outputs to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,8 @@ boot/loader/*.bin
 boot/loader/entry
 fs.img
 os.img
+os.iso
+isodir/
 user/*/*.bin
 
 # Intermediate build files


### PR DESCRIPTION
## Summary
- ignore `os.iso` and `isodir/`
- these are already cleaned in the `make clean` rule

## Testing
- `make clean`

------
https://chatgpt.com/codex/tasks/task_e_68411f455eac8324a81a2403d4d45228