### PR TITLE
Add Multiboot2 header and section

### DIFF
--- a/link.lds
+++ b/link.lds
@@ -3,26 +3,38 @@ ENTRY(start)
 
 SECTIONS
 {
-    . = 0xffff800000200000;
-	
-    .text : {
+    KERNEL_PHYS_BASE = 0x200000;
+    KERNEL_VIRT_BASE = 0xffff800000000000;
+
+    /* Place the multiboot2 header near the start of the file. */
+    . = KERNEL_PHYS_BASE;
+    .multiboot : {
+        KEEP(*(.multiboot))
+    }
+
+    /* Higher half kernel sections. */
+    . = KERNEL_VIRT_BASE + KERNEL_PHYS_BASE;
+
+    .text : AT(LOADADDR(.multiboot) + SIZEOF(.multiboot)) {
         *(.text)
     }
 
-    .rodata : {
+    .rodata : AT(LOADADDR(.text) + SIZEOF(.text)) {
         *(.rodata)
+        *(.eh_frame*)
     }
 
     . = ALIGN(16);
-    .data : {
+    .data : AT(LOADADDR(.rodata) + SIZEOF(.rodata)) {
         *(.data)
+        *(.got*)
     }
 
-    .bss : {
+    .bss : AT(LOADADDR(.data) + SIZEOF(.data)) {
         PROVIDE(bss_start = .);
         *(.bss)
         PROVIDE(bss_end = .);
     }
-    
+
     PROVIDE(end = .);
 }

--- a/src/arch/x86/multiboot_header.asm
+++ b/src/arch/x86/multiboot_header.asm
@@ -1,0 +1,20 @@
+section .multiboot
+extern start
+align 8
+multiboot_header_start:
+    dd 0xe85250d6             ; magic
+    dd 0                      ; architecture (i386/amd64)
+    dd multiboot_header_end - multiboot_header_start
+    dd -(0xe85250d6 + 0 + (multiboot_header_end - multiboot_header_start))
+
+    ; Entry address tag
+    dw 3                       ; type
+    dw 0                       ; flags
+    dd 16                      ; size of this tag
+    dq start                   ; kernel entry point
+
+    ; End tag
+    dw 0
+    dw 0
+    dd 8
+multiboot_header_end:


### PR DESCRIPTION
## Summary
- add a multiboot2 header for GRUB in `src/arch/x86/multiboot_header.asm`
- place `.multiboot` section in the linker script and calculate physical addresses

## Testing
- `make kernel`
- `grub-file --is-x86-multiboot2 kernel.elf`

------
https://chatgpt.com/codex/tasks/task_e_684120b2e0888324bf3f6de5c509bc21