### PR TITLE
Add size check for os.img

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,6 +105,9 @@ os.img: boot/boot.bin boot/loader/loader.bin $(FS_IMG)
 	dd if=boot/loader/loader.bin of=$@ bs=512 \
 	count=$$LOADER_SECTORS seek=1 conv=notrunc
 	dd if=$(FS_IMG) of=$@ bs=512 seek=63 conv=notrunc
+	@actual=$$(stat -c '%s' $@); \
+	[ $$actual -ge 100000000 ] || \
+	    { echo 'Error: os.img too small; filesystem missing?' >&2; exit 1; }
 
 # User programs
 users: libc user/ls/ls.elf user/test/test.elf user/totalmem/totalmem.elf user/user1/user.elf user/ping/ping.elf user/cow/cow.elf

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Run `make` at the repository root.  This compiles the kernel, bootloader
 and user programs and produces `os.img`.  If `grub-mkrescue` is
 available an additional ISO image `os.iso` is created.  The ISO build
 relies on the `grub-mkrescue` tool (install the `grub-pc-bin` package on Debian-based systems).  The resulting image should be
-roughly 100&nbsp;MB because it embeds a small FAT filesystem.
+around 105&nbsp;MB because it embeds a small FAT filesystem.
 
 ```bash
 make


### PR DESCRIPTION
## Summary
- ensure `os.img` is at least 100MB
- document expected image size

## Testing
- `make os.img` *(fails: No rule to make target 'kernel.elf')*

------
https://chatgpt.com/codex/tasks/task_e_6841238838848324b66c66367e7fad1d