### PR TITLE
Fix README on os.img size

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,11 @@ CROSS=$HOME/opt/cross/bin/x86_64-elf- make
 ## Building
 
 Run `make` at the repository root.  This compiles the kernel, bootloader
-and user programs and produces `os.img`.  If `grub-mkrescue` is
-available an additional ISO image `os.iso` is created.  The ISO build
-relies on the `grub-mkrescue` tool (install the `grub-pc-bin` package on Debian-based systems).  The resulting image should be
-around 105&nbsp;MB because it embeds a small FAT filesystem.
+and user programs and produces `os.img`.  The resulting `os.img` is
+around 105&nbsp;MB because it embeds a small FAT filesystem.  If
+`grub-mkrescue` is available an additional ISO image `os.iso` is created.
+The ISO build relies on the `grub-mkrescue` tool (install the
+`grub-pc-bin` package on Debian-based systems).
 
 ```bash
 make


### PR DESCRIPTION
## Summary
- clarify approximate size of `os.img`

## Testing
- `make os.img` *(fails: No rule to make target 'kernel.elf', needed by 'fs.img')*

------
https://chatgpt.com/codex/tasks/task_e_684128526d888324b6151144917f6d8c