### PR TITLE
Fix FS register after returning to real mode

### DIFF
--- a/boot/loader/loader.asm
+++ b/boot/loader/loader.asm
@@ -102,8 +102,7 @@ LoadFS:
 
 BigRealMode:
     sti
-    xor ax,ax
-    mov fs,ax
+    ; FS already contains 0x10 from the protected-mode setup
     mov ebx,[0x7dc6]        ; filesystem start LBA
     mov eax,[0x7dca]        ; partition size in sectors
     mov ecx,100


### PR DESCRIPTION
## Summary
- keep `fs` selector when exiting protected mode

## Testing
- `make all`

------
https://chatgpt.com/codex/tasks/task_e_68412ae3904883249236fc826ef97412