### PR TITLE
Fix executable stack warnings

### DIFF
--- a/boot/boot.asm
+++ b/boot/boot.asm
@@ -70,4 +70,4 @@ times (0x1be-($-$$)) db 0
     db 0xaa
 
 	
-section .note.GNU-stack
+section .note.GNU-stack noalloc noexec nowrite progbits

--- a/boot/loader/entry.asm
+++ b/boot/loader/entry.asm
@@ -18,4 +18,4 @@ End:
     jmp End
 
 
-section .note.GNU-stack
+section .note.GNU-stack noalloc noexec nowrite progbits

--- a/boot/loader/lib.asm
+++ b/boot/loader/lib.asm
@@ -42,4 +42,4 @@ memmove:
     cld
     ret
     
-section .note.GNU-stack
+section .note.GNU-stack noalloc noexec nowrite progbits

--- a/boot/loader/loader.asm
+++ b/boot/loader/loader.asm
@@ -338,4 +338,4 @@ Gdt64Ptr: dw Gdt64Len-1
 
 CModule:
     
-section .note.GNU-stack
+section .note.GNU-stack noalloc noexec nowrite progbits

--- a/libc/src/lib.asm
+++ b/libc/src/lib.asm
@@ -42,4 +42,4 @@ memmove:
     cld
     ret
     
-section .note.GNU-stack
+section .note.GNU-stack noalloc noexec nowrite progbits

--- a/libc/src/syscall.asm
+++ b/libc/src/syscall.asm
@@ -350,4 +350,4 @@ get_sched_info:
 
 
 
-section .note.GNU-stack
+section .note.GNU-stack noalloc noexec nowrite progbits

--- a/src/arch/x86/kernel.asm
+++ b/src/arch/x86/kernel.asm
@@ -101,4 +101,4 @@ End:
     jmp End
 
 
-section .note.GNU-stack
+section .note.GNU-stack noalloc noexec nowrite progbits

--- a/src/arch/x86/lib.asm
+++ b/src/arch/x86/lib.asm
@@ -42,4 +42,4 @@ memmove:
     cld
     ret
     
-section .note.GNU-stack
+section .note.GNU-stack noalloc noexec nowrite progbits

--- a/src/arch/x86/multiboot_header.asm
+++ b/src/arch/x86/multiboot_header.asm
@@ -18,3 +18,4 @@ multiboot_header_start:
     dw 0
     dd 8
 multiboot_header_end:
+section .note.GNU-stack noalloc noexec nowrite progbits

--- a/src/arch/x86/smp.asm
+++ b/src/arch/x86/smp.asm
@@ -43,4 +43,4 @@ send_ipi:
     or edx, 0x00004000
     mov dword [rax + ICR_LOW], edx
     ret
-section .note.GNU-stack
+section .note.GNU-stack noalloc noexec nowrite progbits

--- a/src/arch/x86/trap.asm
+++ b/src/arch/x86/trap.asm
@@ -249,4 +249,4 @@ in_byte:
     ret   
 
 
-section .note.GNU-stack
+section .note.GNU-stack noalloc noexec nowrite progbits

--- a/user/cow/start.asm
+++ b/user/cow/start.asm
@@ -7,4 +7,4 @@ start:
     call main
     call exitu
     jmp $
-section .note.GNU-stack
+section .note.GNU-stack noalloc noexec nowrite progbits

--- a/user/ls/start.asm
+++ b/user/ls/start.asm
@@ -7,4 +7,4 @@ start:
     call main
     call exitu
     jmp $
-section .note.GNU-stack
+section .note.GNU-stack noalloc noexec nowrite progbits

--- a/user/ping/start.asm
+++ b/user/ping/start.asm
@@ -7,4 +7,4 @@ start:
     call main
     call exitu
     jmp $
-section .note.GNU-stack
+section .note.GNU-stack noalloc noexec nowrite progbits

--- a/user/test/start.asm
+++ b/user/test/start.asm
@@ -7,4 +7,4 @@ start:
     call main
     call exitu
     jmp $
-section .note.GNU-stack
+section .note.GNU-stack noalloc noexec nowrite progbits

--- a/user/totalmem/start.asm
+++ b/user/totalmem/start.asm
@@ -7,4 +7,4 @@ start:
     call main
     call exitu
     jmp $
-section .note.GNU-stack
+section .note.GNU-stack noalloc noexec nowrite progbits

--- a/user/user1/start.asm
+++ b/user/user1/start.asm
@@ -7,4 +7,4 @@ start:
     call main
     call exitu
     jmp $
-section .note.GNU-stack
+section .note.GNU-stack noalloc noexec nowrite progbits


### PR DESCRIPTION
## Summary
- annotate all NASM files with `.note.GNU-stack` to disable the executable stack

## Testing
- `make clean`
- `make all -j$(nproc)` *(fails: `ld: warning: entry has a LOAD segment with RWX permissions`)*

------
https://chatgpt.com/codex/tasks/task_e_6841ae83f7a883249087b875c6e2ad0e