### PR TITLE
Add 32‑bit entry transition stub

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ LDFLAGS = -nostdlib
 C_SRCS := $(wildcard src/kernel/*.c)
 DRIVER_SRCS := $(wildcard src/drivers/net/*.c)
 NET_SRCS := $(wildcard src/net/*.c)
-ASM_SRCS := $(wildcard src/arch/x86/*.asm)
+ASM_SRCS := $(sort $(wildcard src/arch/x86/*.asm) src/arch/x86/start32.asm)
 C_OBJS := $(patsubst src/kernel/%.c,$(OBJDIR)/%.o,$(C_SRCS)) \
 $(patsubst src/drivers/net/%.c,$(OBJDIR)/%.o,$(DRIVER_SRCS)) \
 $(patsubst src/net/%.c,$(OBJDIR)/%.o,$(NET_SRCS))

--- a/src/arch/x86/kernel.asm
+++ b/src/arch/x86/kernel.asm
@@ -17,6 +17,7 @@ TssDesc:
 
 Gdt64Len: equ $-Gdt64
 
+global Gdt64Ptr
 Gdt64Ptr: dw Gdt64Len-1
           dq Gdt64
 
@@ -30,9 +31,9 @@ TssLen: equ $-Tss
 
 section .text
 extern KMain
-global start
+global start64
 
-start:
+start64:
     mov rax,Gdt64Ptr
     lgdt [rax]
 

--- a/src/arch/x86/multiboot_header.asm
+++ b/src/arch/x86/multiboot_header.asm
@@ -1,5 +1,5 @@
 section .multiboot
-extern start
+extern start32
 align 8
 multiboot_header_start:
     dd 0xe85250d6             ; magic
@@ -11,7 +11,7 @@ multiboot_header_start:
     dw 3                       ; type
     dw 0                       ; flags
     dd 16                      ; size of this tag
-    dq start                   ; kernel entry point
+    dq start32                 ; kernel entry point
 
     ; End tag
     dw 0

--- a/src/arch/x86/start32.asm
+++ b/src/arch/x86/start32.asm
@@ -1,0 +1,55 @@
+[BITS 32]
+%define KERNEL_BASE 0xffff800000000000
+
+section .text
+
+global start32
+global start
+extern start64
+extern Gdt64Ptr
+%define KERNEL_PHYS_BASE 0x200000
+
+start:
+start32:
+    ; zero page table area
+    mov edi,0x70000
+    xor eax,eax
+    mov ecx,0x10000/4
+    rep stosd
+
+    ; setup low identity mapping via 1 GiB page
+    mov dword[0x70000],0x71007
+    mov dword[0x71000],10000111b
+
+    ; map kernel virtual base to same physical memory
+    mov eax,(KERNEL_BASE>>39)
+    and eax,0x1ff
+    mov dword[0x70000+eax*8],0x72003
+    mov dword[0x72000],10000011b
+
+    ; load 64-bit GDT for transition
+    mov eax,(Gdt64Ptr - KERNEL_BASE + KERNEL_PHYS_BASE)
+    lgdt [eax]
+
+    ; enable PAE
+    mov eax,cr4
+    or eax,(1<<5)
+    mov cr4,eax
+
+    ; load page table
+    mov eax,0x70000
+    mov cr3,eax
+
+    ; enable LME
+    mov ecx,0xc0000080
+    rdmsr
+    or eax,(1<<8)
+    wrmsr
+
+    ; enable paging
+    mov eax,cr0
+    or eax,(1<<31)
+    mov cr0,eax
+
+    ; jump to 64-bit entry
+    jmp 08:(start64 - KERNEL_BASE + KERNEL_PHYS_BASE)


### PR DESCRIPTION
## Summary
- add start32.asm to enter long mode
- rename kernel start label to `start64`
- point Multiboot header to new 32‑bit entry
- include start32.asm when building the kernel

## Testing
- `make iso`
- `make run-iso` *(fails: gtk initialization failed)*

------
https://chatgpt.com/codex/tasks/task_e_684263090d9c8324ab4b97a72909eab9